### PR TITLE
GPS9 Tag Support

### DIFF
--- a/ByteUtil.cs
+++ b/ByteUtil.cs
@@ -72,16 +72,27 @@ namespace Cromatix.MP4Reader
 
         internal static uint BytesToInt(byte[] array, int startPos)
         {
-            var byteSpan = new ReadOnlySpan<byte>(array, startPos, 4);
+            return BytesToInt(array.AsSpan(startPos));
+        }
+        internal static uint BytesToInt(ReadOnlySpan<byte> array)
+        {
+            var byteSpan = array.Slice(0,4);
             return BitConverter.ToUInt32(byteSpan);
         }
 
         internal static ushort BytesToShort(byte[] array, int startPos)
         {
-            var byteSpan = new ReadOnlySpan<byte>(array, startPos, 2);
+            return BytesToShort(array.AsSpan(startPos));
+        }
+        internal static ushort BytesToShort(ReadOnlySpan<byte> array)
+        {
+            var byteSpan = array.Slice(0,2);
             return BitConverter.ToUInt16(byteSpan);
         }
 
+        internal static int HexToInt(uint num) {
+            return HexToInt((int)num);
+        }
         internal static int HexToInt(int num)
         {
             return ((num & 0xff) << 24) | ((num & 0xff00) << 8) | ((num >> 8) & 0xff00) | ((num >> 24) & 0xff);


### PR DESCRIPTION
The latest GoPro 11 cameras do not emit GPS5 KLVs anymore. This code pulls data from the new GPS9 KLV into the existing data structures and should coexist perfectly well with the older GPS5 klvs